### PR TITLE
Handle contact phone numbers.

### DIFF
--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -43,6 +43,11 @@ class CallsController < ApplicationController
       roster["roster"]["roster_telephone_numbers"].each do |phone|
         phone_numbers << phone["phone_number"] unless phone["phone_number"].nil?
       end
+      roster["contacts"].each do |contact|
+        contact["contact_telephone_numbers"].each do |phone|
+          phone_numbers << phone["phone_number"] unless phone["phone_number"].blank?
+        end
+      end
     end
 
     # Build message

--- a/app/helpers/call_helper.rb
+++ b/app/helpers/call_helper.rb
@@ -1,6 +1,7 @@
 module CallHelper
   def has_number(roster)
-    return "no_number" if roster["roster"]["roster_telephone_numbers"].empty?
+    contact_phones = contact_phone_array(roster)
+    return "no_number" if roster["roster"]["roster_telephone_numbers"].empty? && contact_phones.empty?
   end
 
   def format_numbers(roster)
@@ -12,6 +13,26 @@ module CallHelper
       phone_number = phone["phone_number"]
       phones.push phone_label.blank? ? phone_number : "#{phone_label} : #{phone_number}"
     end
+    contact_phone_array(roster).each do |phone|
+      phone_label = phone[1]["label"]
+      phone_number = phone[1]["phone_number"]
+      contact_name = phone[0]["first"] + " " + phone[0]["last"]
+      phone_string = phone_label.blank? ? phone_number : "#{phone_label} : #{phone_number}"
+      phone_string = phone_string + " (#{contact_name})" unless contact_name.blank?
+      phones.push phone_string
+    end
     phones.join(', ')
+  end
+
+  private
+
+  def contact_phone_array(roster)
+    contact_phones = []
+    roster["roster"]["contacts"].each do |contact|
+      contact["contact_telephone_numbers"].each do |phone|
+        contact_phones.push [contact, phone]
+      end
+    end
+    contact_phones
   end
 end


### PR DESCRIPTION
This change allows for displaying and calling of contact phone numbers.
Many youth players don't put any phone numbers on the roster itself, but
instead just create contacts for mom and dad and attach the phone
numbers there.
